### PR TITLE
Storage options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [v0.2.12](https://github.com/Bejibun-Framework/bejibun-core/compare/v0.2.1...v0.2.12) - 2026-02-13
+## [v0.2.12](https://github.com/Bejibun-Framework/bejibun-core/compare/v0.2.1...v0.2.12) - 2026-02-22
 
 ### 🩹 Fixes
 

--- a/src/builders/StorageBuilder.ts
+++ b/src/builders/StorageBuilder.ts
@@ -1,3 +1,4 @@
+import type {StorageDisk, StorageOptions} from "@/types/storage";
 import App from "@bejibun/app";
 import Logger from "@bejibun/logger";
 import {defineValue, isEmpty} from "@bejibun/utils";
@@ -7,7 +8,6 @@ import fs from "fs";
 import DiskConfig from "@/config/disk";
 import DiskException from "@/exceptions/DiskException";
 import DiskDriverEnum from "@/enums/DiskDriverEnum";
-import {StorageDisk} from "@/types/storage";
 
 export default class StorageBuilder {
     protected conf: Record<string, any>;
@@ -120,17 +120,17 @@ export default class StorageBuilder {
         return data;
     }
 
-    public async put(filepath: string, content: any): Promise<void> {
+    public async put(filepath: string, content: any, options?: StorageOptions): Promise<void> {
         if (isEmpty(filepath)) throw new DiskException("The file path is required.");
         if (isEmpty(content)) throw new DiskException("The content is required.");
 
         try {
             switch (this.driver) {
                 case DiskDriverEnum.Local:
-                    await Bun.write(path.resolve(this.currentDisk.root, filepath), content);
+                    await Bun.write(path.resolve(this.currentDisk.root, filepath), content, options);
                     break;
                 case DiskDriverEnum.S3:
-                    await this.s3.write(filepath, content);
+                    await this.s3.write(filepath, content, options);
                     break;
                 default:
                     break;

--- a/src/facades/Storage.ts
+++ b/src/facades/Storage.ts
@@ -1,5 +1,5 @@
+import type {StorageDisk, StorageOptions} from "@/types/storage";
 import StorageBuilder from "@/builders/StorageBuilder";
-import {StorageDisk} from "@/types/storage";
 
 export default class Storage {
     public static build(disk: StorageDisk): StorageBuilder {
@@ -22,7 +22,7 @@ export default class Storage {
         return await new StorageBuilder().get(path);
     }
 
-    public static async put(path: string, content: any): Promise<void> {
+    public static async put(path: string, content: any, options?: StorageOptions): Promise<void> {
         return await new StorageBuilder().put(path, content);
     }
 

--- a/src/types/router.d.ts
+++ b/src/types/router.d.ts
@@ -4,19 +4,19 @@ export type HandlerType = (request: Bun.BunRequest, server: Bun.Server) => Promi
 export type RouterMethodMap = Record<string, HandlerType>;
 export type RouterGroup = Record<string, RouterMethodMap | RouterGroup>;
 export type RawRoute = {
-    prefix: string,
-    middlewares: Array<IMiddleware>,
-    namespace: string,
-    method: string,
-    path: string,
-    handler: string | HandlerType
+    prefix: string;
+    middlewares: Array<IMiddleware>;
+    namespace: string;
+    method: string;
+    path: string;
+    handler: string | HandlerType;
 };
 export type Route = {
-    raw: RawRoute,
-    route: RouterGroup
+    raw: RawRoute;
+    route: RouterGroup;
 };
 export type RawsRoute = {
-    raws: Array<Route>,
-    routes: Array<RouterGroup>
+    raws: Array<Route>;
+    routes: Array<RouterGroup>;
 };
 export type ResourceAction = "index" | "store" | "show" | "update" | "destroy";

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -1,4 +1,44 @@
 export type StorageDisk = {
-    driver: string,
-    [key: string]: unknown
+    driver: string;
+    [key: string]: unknown;
+};
+
+export type StorageOptions = {
+    mode?: number;
+    createPath?: boolean;
+    acl?:
+        | "private"
+        | "public-read"
+        | "public-read-write"
+        | "aws-exec-read"
+        | "authenticated-read"
+        | "bucket-owner-read"
+        | "bucket-owner-full-control"
+        | "log-delivery-write";
+    bucket?: string;
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    endpoint?: string;
+    virtualHostedStyle?: boolean;
+    partSize?: number;
+    queueSize?: number;
+    retry?: number;
+    type?: string;
+    contentDisposition?: string | undefined;
+    storageClass?:
+        | "STANDARD"
+        | "DEEP_ARCHIVE"
+        | "EXPRESS_ONEZONE"
+        | "GLACIER"
+        | "GLACIER_IR"
+        | "INTELLIGENT_TIERING"
+        | "ONEZONE_IA"
+        | "OUTPOSTS"
+        | "REDUCED_REDUNDANCY"
+        | "SNOW"
+        | "STANDARD_IA";
+    requestPayer?: boolean;
+    highWaterMark?: number;
 };


### PR DESCRIPTION
Added storage options on `Storage.put()`

```ts
export type StorageOptions = {
    mode?: number;
    createPath?: boolean;
    acl?:
        | "private"
        | "public-read"
        | "public-read-write"
        | "aws-exec-read"
        | "authenticated-read"
        | "bucket-owner-read"
        | "bucket-owner-full-control"
        | "log-delivery-write";
    bucket?: string;
    region?: string;
    accessKeyId?: string;
    secretAccessKey?: string;
    sessionToken?: string;
    endpoint?: string;
    virtualHostedStyle?: boolean;
    partSize?: number;
    queueSize?: number;
    retry?: number;
    type?: string;
    contentDisposition?: string | undefined;
    storageClass?:
        | "STANDARD"
        | "DEEP_ARCHIVE"
        | "EXPRESS_ONEZONE"
        | "GLACIER"
        | "GLACIER_IR"
        | "INTELLIGENT_TIERING"
        | "ONEZONE_IA"
        | "OUTPOSTS"
        | "REDUCED_REDUNDANCY"
        | "SNOW"
        | "STANDARD_IA";
    requestPayer?: boolean;
    highWaterMark?: number;
};
```